### PR TITLE
relax elixir version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExPrintf.Mixfile do
   def project do
     [ app: :exprintf,
       version: "0.1.5",
-      elixir: "~> 0.14.3 or ~> 0.15.0 or ~> 1.0.0",
+      elixir: "~> 0.14.3 or ~> 0.15.0 or ~> 1.0",
       deps: deps,
       description: description,
       package: package


### PR DESCRIPTION
- from "~> 1.0.0" to "~> 1.0", specifying the entire 1.x series
- tests pass against elixir 1.1.0-dev
- can always retighten if incompatibilities show up later