### PR TITLE
Suppress warning on unsafe variable

### DIFF
--- a/lib/exprintf.ex
+++ b/lib/exprintf.ex
@@ -174,8 +174,9 @@ defmodule ExPrintf do
   
   defp do_handle_options(state, options) do
     # If we have digits with precision (e.g %0.4d) we interpret it as padding
-    if options[:digits] == true do
-      state = %{state | padding: true, width: state.precision, precision: 0}
+    state = case options[:digits] do
+      true -> %{state | padding: true, width: state.precision, precision: 0}
+      _    -> state
     end
     
     sign      = get_sign_chars(state.negative)


### PR DESCRIPTION
I got the following warnings when I compiled the latest version:

```
$ mix compile
==> earmark
Compiling 3 files (.erl)
Compiling 19 files (.ex)
Generated earmark app
==> ex_doc
Compiling 14 files (.ex)
Generated ex_doc app
==> exprintf
Compiling 1 file (.ex)
warning: the variable "state" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/exprintf.ex:181

warning: the variable "state" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/exprintf.ex:182

warning: the variable "state" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/exprintf.ex:183

Generated exprintf app
```

So I rewrote it so that these warnings do not show up.